### PR TITLE
Transfer config

### DIFF
--- a/forge.config.js
+++ b/forge.config.js
@@ -12,7 +12,7 @@ module.exports = {
        * @type {import("@electron-forge/maker-squirrel").MakerSquirrelConfig}
        */
       config: {
-        iconUrl: "./Assets/Electunes.ico",
+        iconUrl: `file:///${__dirname}/Assets/Electunes.ico`,
         setupIcon: "./Assets/Electunes.ico"
       }
     },

--- a/forge.config.js
+++ b/forge.config.js
@@ -1,0 +1,51 @@
+/**
+ * @type {import("@electron-forge/shared-types").ForgeConfig}
+ */
+module.exports = {
+  packagerConfig: {
+      icon: "Assets/Electunes",
+  },
+  makers: [
+    {
+      name: "@electron-forge/maker-squirrel",
+      /**
+       * @type {import("@electron-forge/maker-squirrel").MakerSquirrelConfig}
+       */
+      config: {
+        iconUrl: "Assets/Electunes.ico",
+        setupIcon: "Assets/Electunes.ico"
+      }
+    },
+    {
+      name: "@electron-forge/maker-dmg",
+      /**
+       * @type {import("@electron-forge/maker-dmg").MakerDMGConfig}
+       */
+      config: {
+        icon: "Assets/Electunes.icns"
+      },
+    },
+    {
+      name: "@electron-forge/maker-deb",
+      /**
+       * @type {import("@electron-forge/maker-deb").MakerDebConfig}
+       */
+      config: {
+        options: {
+          icon: "Assets/Electunes.png"
+        }
+      }
+    },
+    {
+      name: "@electron-forge/maker-rpm",
+      /**
+       * @type {import("@electron-forge/maker-rpm").MakerRpmConfig}
+       */
+      config: {
+        options: {
+          icon: "Assets/Electunes.png"
+        }
+      }
+    }
+  ]
+}

--- a/forge.config.js
+++ b/forge.config.js
@@ -12,8 +12,8 @@ module.exports = {
        * @type {import("@electron-forge/maker-squirrel").MakerSquirrelConfig}
        */
       config: {
-        iconUrl: "Assets/Electunes.ico",
-        setupIcon: "Assets/Electunes.ico"
+        iconUrl: "./Assets/Electunes.ico",
+        setupIcon: "./Assets/Electunes.ico"
       }
     },
     {

--- a/package.json
+++ b/package.json
@@ -18,44 +18,7 @@
   },
   "license": "MIT",
   "config": {
-    "forge": {
-      "packagerConfig": {
-        "icon": "Assets/Electunes"
-      },
-      "makers": [
-        {
-          "name": "@electron-forge/maker-squirrel",
-          "config": {
-            "options": {
-              "iconUrl": "Assets/Electunes.png",
-              "setupIcon": "Assets/Electunes.png"
-            }
-          }
-        },
-        {
-          "name": "@electron-forge/maker-dmg",
-          "config": {
-            "icon": "Assets/Electunes.icns"
-          }
-        },
-        {
-          "name": "@electron-forge/maker-deb",
-          "config": {
-            "options": {
-              "icon": "Assets/Electunes.png"
-            }
-          }
-        },
-        {
-          "name": "@electron-forge/maker-rpm",
-          "config": {
-            "options": {
-              "icon": "Assets/Electunes.png"
-            }
-          }
-        }
-      ]
-    }
+    "forge": "./forge.config.js"
   },
   "dependencies": {
     "about-window": "^1.15.2",


### PR DESCRIPTION
This will transfer the configuration based on `package.json` to new type-assisted `forge.config.js` which is supported by Electron Forge.

This maybe fix Squirrel.Windows not bundle with icon(not tested but built).