### PR TITLE
Create Universal package for macosx

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Package prebuild
         run: npm run build
-        if: "!(matrix.os == macos-12)"
+        if: "!(matrix.os == \"macos-12\")"
       - name: Package prebuild (macOS)
         run: npm run build:mac
-        if: matrix.os == macos-12
+        if: matrix.os == "macos-12"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Package prebuild
         run: npm run build
-        if: "!(matrix.os == \"macos-12\")"
+        if: "!(matrix.os == macos-12)"
       - name: Package prebuild (macOS)
         run: npm run build:mac
         if: matrix.os == "macos-12"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Package prebuild
         run: npm run build
-        if: "!(matrix.os == macos-12)"
+        if: "!(matrix.os == 'macos-12')"
       - name: Package prebuild (macOS)
         run: npm run build:mac
-        if: matrix.os == "macos-12"
+        if: matrix.os == 'macos-12'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
-
       - name: Install Node v18
         uses: actions/setup-node@v3
         with:
@@ -31,3 +30,7 @@ jobs:
 
       - name: Package prebuild
         run: npm run build
+        if: "!(matrix.os == macos-12)"
+      - name: Package prebuild (macOS)
+        run: npm run build:mac
+        if: matrix.os == macos-12

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,11 @@ jobs:
 
       - name: Package prebuild
         run: npm run build
+        if: "!(matrix.os == macos-12)"
+      
+      - name: Package prebuild
+        run: npm run build:mac
+        if: matrix.os == macos-12
 
       - uses: actions/upload-artifact@v3
         with:

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "start": "chcp 65001 && electron-forge start",
     "build": "electron-forge make",
+    "build:mac": "electron-forge make --arch=universal",
     "save": "npm install --save"
   },
   "keywords": [


### PR DESCRIPTION
Adds OSX specific universal package build tasks.
**not work on test because `@electron/universal` not work properly on M1**
maybe work on Intel-based Macs?